### PR TITLE
Firefox support

### DIFF
--- a/coffeescripts/background.coffee
+++ b/coffeescripts/background.coffee
@@ -145,7 +145,7 @@ defaultUserPreferences = {
   
     # suggested values to all users  -- any can be overriden with the "Research this URL" button
       # unfortunately, because of Chrome's discouragement of storing sensitive 
-      # user info with chrome.storage, blacklists are fixed for now . see: https://news.ycombinator.com/item?id=9993030
+      # user info with browser.storage, blacklists are fixed for now . see: https://news.ycombinator.com/item?id=9993030
   urlSubstring_blacklists: 
     anyMatch: [
       'facebook.com'
@@ -614,7 +614,7 @@ requestRedditOathToken = (kiwi_reddit_oauth) ->
           client_id: kiwi_reddit_oauth.client_id
           device_id: kiwi_reddit_oauth.device_id
         
-        chrome.storage.local.set(setObj, (data) ->
+        browser.storage.local.set(setObj, (data) ->
           
           setTimeout_forRedditRefresh(token_lifespan_timestamp, setObj.kiwi_reddit_oauth, true)
           
@@ -691,7 +691,7 @@ requestProductHuntOauthToken = (kiwi_productHunt_oauth) ->
           client_id: kiwi_productHunt_oauth.client_id
           client_secret: kiwi_productHunt_oauth.client_secret
         
-        chrome.storage.local.set(setObj, (_data) ->
+        browser.storage.local.set(setObj, (_data) ->
           # console.log ' set product hunt oauth'
           setTimeout_forProductHuntRefresh(token_lifespan_timestamp, setObj.kiwi_productHunt_oauth, true)
           
@@ -706,7 +706,7 @@ requestProductHuntOauthToken = (kiwi_productHunt_oauth) ->
   $.ajax( queryObj )
 
 # authenticate with Reddit's OAUTH2, so we can be a good webizen
-chrome.storage.local.get(null, (allItemsInLocalStorage) ->
+browser.storage.local.get(null, (allItemsInLocalStorage) ->
   currentTime = Date.now()
   
   # console.log ' trying yo ' 
@@ -834,7 +834,7 @@ returnNumberOfActiveServices = (servicesInfo) ->
   return numberOfActiveServices
 
 sendParcel = (parcel) ->
-  outPort = chrome.extension.connect({name: "kiwi_fromBackgroundToPopup"})
+  outPort = browser.runtime.connect({name: "kiwi_fromBackgroundToPopup"})
   
   if !parcel.msg? or !parcel.forUrl?
     return false
@@ -851,7 +851,7 @@ _save_a_la_carte = (parcel) ->
   setObj = {}
   setObj[parcel.keyName] = parcel.newValue
   
-  chrome.storage[parcel.localOrSync].set(setObj, (data) ->
+  browser.storage[parcel.localOrSync].set(setObj, (data) ->
     if !tempResponsesStore? or !tempResponsesStore.services?
       tempResponsesStoreServices = {}
     else
@@ -863,7 +863,7 @@ _save_a_la_carte = (parcel) ->
   )
 
 
-chrome.extension.onConnect.addListener((port) ->
+browser.runtime.onConnect.addListener((port) ->
   if port.name is 'kiwi_fromBackgroundToPopup'
     popupOpen = true
     
@@ -900,7 +900,7 @@ chrome.extension.onConnect.addListener((port) ->
           if dataFromPopup.customSearchRequest? and dataFromPopup.customSearchRequest.queryString? and
               dataFromPopup.customSearchRequest.queryString != ''
             
-            chrome.storage.sync.get(null, (allItemsInSyncedStorage) -> 
+            browser.storage.sync.get(null, (allItemsInSyncedStorage) -> 
               
               if allItemsInSyncedStorage['kiwi_servicesInfo']?
                 #console.log 'when kiwiPP_post_customSearch3'
@@ -1033,12 +1033,12 @@ chrome.extension.onConnect.addListener((port) ->
 
 initialize = (currentUrl) ->
   
-  chrome.storage.sync.get(null, (allItemsInSyncedStorage) ->
+  browser.storage.sync.get(null, (allItemsInSyncedStorage) ->
     
     if !allItemsInSyncedStorage['kiwi_servicesInfo']?
       
         # we set the defaults in localStorage if servicesInfo doesn't exist in localStorage 
-      chrome.storage.sync.set({'kiwi_servicesInfo': defaultServicesInfo}, (servicesInfo) ->
+      browser.storage.sync.set({'kiwi_servicesInfo': defaultServicesInfo}, (servicesInfo) ->
         getUrlResults_to_refreshBadgeIcon(defaultServicesInfo, currentUrl)
       )
       
@@ -1145,7 +1145,7 @@ _save_historyBlob = (kiwi_urlsResultsCache, tabUrl) ->
   tabUrl_hashWordArray = CryptoJS.SHA512(tabUrl)
   tabUrl_hash = tabUrl_hashWordArray.toString(CryptoJS.enc.Latin1)
   
-  chrome.storage.local.get(null, (allItemsInLocalStorage) ->  
+  browser.storage.local.get(null, (allItemsInLocalStorage) ->  
     
     historyString = reduceHashByHalf(tabUrl_hash)
     paddedHistoryString = __randomishStringPadding() + historyString
@@ -1179,7 +1179,7 @@ _save_historyBlob = (kiwi_urlsResultsCache, tabUrl) ->
     
     
     
-    chrome.storage.local.set({'kiwi_historyBlob': newKiwi_historyBlob}, ->
+    browser.storage.local.set({'kiwi_historyBlob': newKiwi_historyBlob}, ->
       
         # console.log 'historyString'
         # console.log historyString
@@ -1297,7 +1297,7 @@ dispatchQuery = (service_info, currentUrl, servicesInfo) ->
     else
       serviceQueryTimestamps[service_info.name] = currentTime
   
-  chrome.storage.local.get(null, (allItemsInLocalStorage) ->
+  browser.storage.local.get(null, (allItemsInLocalStorage) ->
     queryObj = {
       type: "GET"
       url: service_info.queryApi + encodeURIComponent(currentUrl)
@@ -1595,7 +1595,7 @@ dispatchQuery__customSearch = (customSearchQuery, servicesToSearch, service_info
       #console.log queryUrl
       # tagObject might one day accept special parameters like author name, etc
       
-  chrome.storage.local.get(null, (allItemsInLocalStorage) ->
+  browser.storage.local.get(null, (allItemsInLocalStorage) ->
     queryObj = {
       type: "GET"
       url: queryUrl
@@ -1786,7 +1786,7 @@ setPreppedServiceResults__customSearch = (responsePackage, servicesInfo) ->
     
       # NO LONGER STORING URL CACHE IN LOCALSTORAGE - BECAUSE : INFORMATION LEAKAGE / BROKEN EXTENSION SECURITY MODEL
         # get a fresh copy of urls results and reset with updated info
-        # chrome.storage.local.get(null, (allItemsInLocalStorage) ->
+        # browser.storage.local.get(null, (allItemsInLocalStorage) ->
           # #console.log 'trying to save all'
           # if !allItemsInLocalStorage['kiwi_urlsResultsCache']?
           #   allItemsInLocalStorage['kiwi_urlsResultsCache'] = {}
@@ -1816,7 +1816,7 @@ _set_popupParcel = (setWith_urlResults = {}, forUrl, sendPopupParcel, renderView
   setObj_popupParcel.forUrl = tabUrl
   
   
-  chrome.storage.sync.get(null, (allItemsInSyncedStorage) ->
+  browser.storage.sync.get(null, (allItemsInSyncedStorage) ->
     
     if !allItemsInSyncedStorage['kiwi_userPreferences']?
       setObj_popupParcel.kiwi_userPreferences = defaultUserPreferences
@@ -1969,7 +1969,7 @@ setPreppedServiceResults = (responsePackage, servicesInfo) ->
       
         # NO LONGER STORING URL CACHE IN LOCALSTORAGE - BECAUSE 1.) INFORMATION LEAKAGE, 2.) SLOWER
           # get a fresh copy of urls results and reset with updated info
-          # chrome.storage.local.get(null, (allItemsInLocalStorage) ->
+          # browser.storage.local.get(null, (allItemsInLocalStorage) ->
             # #console.log 'trying to save all'
             # if !allItemsInLocalStorage['kiwi_urlsResultsCache']?
             #   allItemsInLocalStorage['kiwi_urlsResultsCache'] = {}
@@ -2550,7 +2550,7 @@ refreshBadge = (servicesInfo, resultsObjForCurrentUrl) ->
    # if Object.keys(resultsObjForCurrentUrl).length == 0
   badgeText = ''
   if abbreviationLettersArray.length == 0
-    chrome.storage.sync.get(null, (allItemsInSyncedStorage) -> 
+    browser.storage.sync.get(null, (allItemsInSyncedStorage) -> 
       if allItemsInSyncedStorage['kiwi_userPreferences']? and allItemsInSyncedStorage['kiwi_userPreferences'].researchModeOnOff == 'off'
         badgeText = 'off'
       else if defaultUserPreferences.researchModeOnOff == 'off'
@@ -2577,7 +2577,7 @@ refreshBadge = (servicesInfo, resultsObjForCurrentUrl) ->
 
 updateBadgeText = (text) ->
   
-  chrome.browserAction.setBadgeText({'text':text.toString()})
+  browser.browserAction.setBadgeText({'text':text.toString()})
 
 
 periodicCleanup = (tab, allItemsInLocalStorage, allItemsInSyncedStorage, initialize_callback) ->
@@ -2628,7 +2628,7 @@ periodicCleanup = (tab, allItemsInLocalStorage, allItemsInSyncedStorage, initial
             
             deletedCount++
         
-        # chrome.storage.local.set({'kiwi_urlsResultsCache':kiwi_urlsResultsCache}, ->
+        # browser.storage.local.set({'kiwi_urlsResultsCache':kiwi_urlsResultsCache}, ->
             
         initialize_callback(tab, allItemsInLocalStorage, allItemsInSyncedStorage)
           
@@ -2683,9 +2683,9 @@ _save_from_popupParcel = (_popupParcel, forUrl, updateToView) ->
   
   _popupParcel.kiwi_userPreferences.autoOffAtUTCmilliTimestamp = _autoOffAtUTCmilliTimestamp
   
-  chrome.storage.sync.set({'kiwi_userPreferences': _popupParcel.kiwi_userPreferences}, ->
+  browser.storage.sync.set({'kiwi_userPreferences': _popupParcel.kiwi_userPreferences}, ->
       
-    chrome.storage.sync.set({'kiwi_servicesInfo': _popupParcel.kiwi_servicesInfo}, ->
+    browser.storage.sync.set({'kiwi_servicesInfo': _popupParcel.kiwi_servicesInfo}, ->
         
       
       if updateToView?
@@ -2798,7 +2798,7 @@ setAutoOffTimer = (resetTimerBool, autoOffAtUTCmilliTimestamp, autoOffTimerValue
 turnResearchModeOff = ->
   #console.log 'turning off research mode - in turnResearchModeOff'
   
-  chrome.storage.sync.get(null, (allItemsInSyncedStorage) -> 
+  browser.storage.sync.get(null, (allItemsInSyncedStorage) -> 
     
     if kiwi_urlsResultsCache[tabUrl]?
       urlResults = kiwi_urlsResultsCache[tabUrl]
@@ -2808,7 +2808,7 @@ turnResearchModeOff = ->
     if allItemsInSyncedStorage.kiwi_userPreferences?
       
       allItemsInSyncedStorage.kiwi_userPreferences.researchModeOnOff = 'off'
-      chrome.storage.sync.set({'kiwi_userPreferences':allItemsInSyncedStorage.kiwi_userPreferences}, ->
+      browser.storage.sync.set({'kiwi_userPreferences':allItemsInSyncedStorage.kiwi_userPreferences}, ->
           _set_popupParcel(urlResults, tabUrl, true)
           if allItemsInSyncedStorage.kiwi_servicesInfo?
             refreshBadge(allItemsInSyncedStorage.kiwi_servicesInfo, urlResults)
@@ -2819,7 +2819,7 @@ turnResearchModeOff = ->
     else
       defaultUserPreferences.researchModeOnOff = 'off'
       
-      chrome.storage.sync.set({'kiwi_userPreferences':defaultUserPreferences}, ->
+      browser.storage.sync.set({'kiwi_userPreferences':defaultUserPreferences}, ->
           
           _set_popupParcel(urlResults, tabUrl, true)
           
@@ -2902,7 +2902,7 @@ proceedWithPreInitCheck = (allItemsInSyncedStorage, allItemsInLocalStorage, over
         setObj =
           kiwi_servicesInfo: defaultServicesInfo
           kiwi_userPreferences: defaultUserPreferences
-        chrome.storage.sync.set(setObj, ->
+        browser.storage.sync.set(setObj, ->
           
           isUrlBlocked = is_url_blocked(defaultUserPreferences.urlSubstring_blacklists, tabUrl)
           if isUrlBlocked == true and overrideResearchModeOff == false
@@ -2999,7 +2999,7 @@ checkForNewDefaultUserPreferenceAttributes_thenProceedWithInitCheck = (allItemsI
     if newServicesInfoAttribute
       setObj['kiwi_servicesInfo'] = newServicesInfo
     
-    chrome.storage.sync.set(setObj, ->
+    browser.storage.sync.set(setObj, ->
         
         # this reminds me of the frog DNA injection from jurassic park
       if newUserPrefsAttribute
@@ -3031,8 +3031,8 @@ initIfNewURL = (overrideSameURLCheck_popupOpen = false, overrideResearchModeOff 
   
   currentTime = Date.now()
   
-  # chrome.tabs.getSelected(null,(tab) ->
-  chrome.tabs.query({ currentWindow: true, active: true }, (tabs) ->
+  # browser.tabs.getSelected(null,(tab) ->
+  browser.tabs.query({ currentWindow: true, active: true }, (tabs) ->
     
     if tabs.length > 0 and tabs[0].url?
         
@@ -3068,9 +3068,9 @@ initIfNewURL = (overrideSameURLCheck_popupOpen = false, overrideResearchModeOff 
       tabUrl_hashWordArray = CryptoJS.SHA512(tabUrl)
       tabUrl_hash = tabUrl_hashWordArray.toString(CryptoJS.enc.Latin1)
       
-      chrome.storage.local.get(null, (allItemsInLocalStorage) ->
+      browser.storage.local.get(null, (allItemsInLocalStorage) ->
         
-        # #console.log 'chrome.storage.local.get(null, (allItemsInLocalStorage) ->  '
+        # #console.log 'browser.storage.local.get(null, (allItemsInLocalStorage) ->  '
         
         sameURLCheck = true
         
@@ -3100,12 +3100,12 @@ initIfNewURL = (overrideSameURLCheck_popupOpen = false, overrideResearchModeOff 
           sameURLCheck = false
         
         #useful for switching window contexts
-        chrome.storage.local.set({'persistentUrlHash': tabUrl_hash}, ->)
+        browser.storage.local.set({'persistentUrlHash': tabUrl_hash}, ->)
         
         if sameURLCheck == false          
           updateBadgeText('')
         
-          chrome.storage.sync.get(null, (allItemsInSyncedStorage) ->
+          browser.storage.sync.get(null, (allItemsInSyncedStorage) ->
             
             checkForNewDefaultUserPreferenceAttributes_thenProceedWithInitCheck(allItemsInSyncedStorage, allItemsInLocalStorage, 
                 overrideSameURLCheck_popupOpen, overrideResearchModeOff, sameURLCheck, tabUrl, currentTime, popupOpen)
@@ -3115,12 +3115,12 @@ initIfNewURL = (overrideSameURLCheck_popupOpen = false, overrideResearchModeOff 
     )
   )
 
-chrome.tabs.onActivated.addListener( -> 
+browser.tabs.onActivated.addListener( -> 
     # nesting function because the Chrome api tab listening functions were exec-ing callback with an integer argument
     initIfNewURL()
   )
 
-chrome.tabs.onUpdated.addListener((tabId , info) ->
+browser.tabs.onUpdated.addListener((tabId , info) ->
     # updateBadgeText('')
     if tabTitleObject? and tabTitleObject.forUrl == tabUrl and !tabTitleObject.tabTitle?
       if (info.status == "complete") 
@@ -3130,7 +3130,7 @@ chrome.tabs.onUpdated.addListener((tabId , info) ->
       initIfNewURL()
   )
 
-chrome.windows.onFocusChanged.addListener( -> 
+browser.windows.onFocusChanged.addListener( -> 
     # nesting function because the Chrome api tab listening functions were exec-ing callback with an integer argument
     initIfNewURL()
   )

--- a/coffeescripts/popup.coffee
+++ b/coffeescripts/popup.coffee
@@ -1915,8 +1915,8 @@ receiveParcel  = (parcel) ->
     
     when 'kiwiPP_popupParcel_ready' 
     
-      chrome.tabs.query({ currentWindow: true, active: true }, (tabs) ->
-      # chrome.tabs.getSelected(null,(tab) ->
+      browser.tabs.query({ currentWindow: true, active: true }, (tabs) ->
+      # browser.tabs.getSelected(null,(tab) ->
         if tabs.length > 0 and tabs[0].status is "complete"
           if tabs[0].url.indexOf('chrome-devtools://') != 0
           
@@ -1939,10 +1939,10 @@ receiveParcel  = (parcel) ->
  
 sendParcel = (parcel) ->
   # console.log 'wtf sent'
-  port = chrome.extension.connect({name: "kiwi_fromBackgroundToPopup"})
+  port = browser.runtime.connect({name: "kiwi_fromBackgroundToPopup"})
   
-  # chrome.tabs.getSelected(null,(tab) ->
-  chrome.tabs.query({ currentWindow: true, active: true }, (tabs) ->
+  # browser.tabs.getSelected(null,(tab) ->
+  browser.tabs.query({ currentWindow: true, active: true }, (tabs) ->
     # console.log 'wtf sent2'
     # console.debug tabs
     if tabs.length > 0 and tabs[0].status is "complete"
@@ -1980,7 +1980,7 @@ sendParcel = (parcel) ->
   )
   
   # listen for other messages
-chrome.extension.onConnect.addListener((port) ->  
+browser.runtime.onConnect.addListener((port) ->  
   if port.name is 'kiwi_fromBackgroundToPopup'
     
     port.onMessage.addListener((pkg) ->

--- a/package/background.js
+++ b/package/background.js
@@ -416,7 +416,7 @@
             client_id: kiwi_reddit_oauth.client_id,
             device_id: kiwi_reddit_oauth.device_id
           };
-          return chrome.storage.local.set(setObj, function(data) {
+          return browser.storage.local.set(setObj, function(data) {
             return setTimeout_forRedditRefresh(token_lifespan_timestamp, setObj.kiwi_reddit_oauth, true);
           });
         }
@@ -494,7 +494,7 @@
             client_id: kiwi_productHunt_oauth.client_id,
             client_secret: kiwi_productHunt_oauth.client_secret
           };
-          return chrome.storage.local.set(setObj, function(_data) {
+          return browser.storage.local.set(setObj, function(_data) {
             return setTimeout_forProductHuntRefresh(token_lifespan_timestamp, setObj.kiwi_productHunt_oauth, true);
           });
         }
@@ -509,7 +509,7 @@
     return $.ajax(queryObj);
   };
 
-  chrome.storage.local.get(null, function(allItemsInLocalStorage) {
+  browser.storage.local.get(null, function(allItemsInLocalStorage) {
     var currentTime, token_timestamp;
     currentTime = Date.now();
     if ((allItemsInLocalStorage.kiwi_productHunt_oauth == null) || (allItemsInLocalStorage.kiwi_productHunt_oauth.token == null)) {
@@ -622,7 +622,7 @@
 
   sendParcel = function(parcel) {
     var outPort;
-    outPort = chrome.extension.connect({
+    outPort = browser.runtime.connect({
       name: "kiwi_fromBackgroundToPopup"
     });
     if ((parcel.msg == null) || (parcel.forUrl == null)) {
@@ -638,7 +638,7 @@
     var setObj;
     setObj = {};
     setObj[parcel.keyName] = parcel.newValue;
-    return chrome.storage[parcel.localOrSync].set(setObj, function(data) {
+    return browser.storage[parcel.localOrSync].set(setObj, function(data) {
       var tempResponsesStoreServices;
       if ((tempResponsesStore == null) || (tempResponsesStore.services == null)) {
         tempResponsesStoreServices = {};
@@ -653,7 +653,7 @@
     });
   };
 
-  chrome.extension.onConnect.addListener(function(port) {
+  browser.runtime.onConnect.addListener(function(port) {
     if (port.name === 'kiwi_fromBackgroundToPopup') {
       popupOpen = true;
       return port.onMessage.addListener(function(dataFromPopup) {
@@ -681,7 +681,7 @@
             break;
           case 'kiwiPP_post_customSearch':
             if ((dataFromPopup.customSearchRequest != null) && (dataFromPopup.customSearchRequest.queryString != null) && dataFromPopup.customSearchRequest.queryString !== '') {
-              return chrome.storage.sync.get(null, function(allItemsInSyncedStorage) {
+              return browser.storage.sync.get(null, function(allItemsInSyncedStorage) {
                 var serviceInfoObject, _j, _len1, _ref1, _results;
                 if (allItemsInSyncedStorage['kiwi_servicesInfo'] != null) {
                   _ref1 = allItemsInSyncedStorage['kiwi_servicesInfo'];
@@ -791,9 +791,9 @@
   });
 
   initialize = function(currentUrl) {
-    return chrome.storage.sync.get(null, function(allItemsInSyncedStorage) {
+    return browser.storage.sync.get(null, function(allItemsInSyncedStorage) {
       if (allItemsInSyncedStorage['kiwi_servicesInfo'] == null) {
-        return chrome.storage.sync.set({
+        return browser.storage.sync.set({
           'kiwi_servicesInfo': defaultServicesInfo
         }, function(servicesInfo) {
           return getUrlResults_to_refreshBadgeIcon(defaultServicesInfo, currentUrl);
@@ -877,7 +877,7 @@
     var tabUrl_hash, tabUrl_hashWordArray;
     tabUrl_hashWordArray = CryptoJS.SHA512(tabUrl);
     tabUrl_hash = tabUrl_hashWordArray.toString(CryptoJS.enc.Latin1);
-    return chrome.storage.local.get(null, function(allItemsInLocalStorage) {
+    return browser.storage.local.get(null, function(allItemsInLocalStorage) {
       var historyString, newKiwi_historyBlob, paddedHistoryString;
       historyString = reduceHashByHalf(tabUrl_hash);
       paddedHistoryString = __randomishStringPadding() + historyString;
@@ -896,7 +896,7 @@
       if ((allItemsInLocalStorage.kiwi_historyBlob != null) && allItemsInLocalStorage.kiwi_historyBlob.indexOf(historyString) > 17000) {
         newKiwi_historyBlob = newKiwi_historyBlob.substring(0, 15500);
       }
-      return chrome.storage.local.set({
+      return browser.storage.local.set({
         'kiwi_historyBlob': newKiwi_historyBlob
       }, function() {});
     });
@@ -1002,7 +1002,7 @@
         serviceQueryTimestamps[service_info.name] = currentTime;
       }
     }
-    return chrome.storage.local.get(null, function(allItemsInLocalStorage) {
+    return browser.storage.local.get(null, function(allItemsInLocalStorage) {
       var queryObj, responsePackage, tryAgainTimestamp;
       queryObj = {
         type: "GET",
@@ -1244,7 +1244,7 @@
         queryUrl = queryUrl + service_info.customSearchTags__convention.string + service_info.customSearchTags[tagIdentifier].string;
       }
     }
-    return chrome.storage.local.get(null, function(allItemsInLocalStorage) {
+    return browser.storage.local.get(null, function(allItemsInLocalStorage) {
       var queryObj, responsePackage;
       queryObj = {
         type: "GET",
@@ -1426,7 +1426,7 @@
     }
     setObj_popupParcel = {};
     setObj_popupParcel.forUrl = tabUrl;
-    return chrome.storage.sync.get(null, function(allItemsInSyncedStorage) {
+    return browser.storage.sync.get(null, function(allItemsInSyncedStorage) {
       var isUrlBlocked, messageName, messageObj, parcel, sentInstance, _i, _len, _ref;
       if (allItemsInSyncedStorage['kiwi_userPreferences'] == null) {
         setObj_popupParcel.kiwi_userPreferences = defaultUserPreferences;
@@ -1988,7 +1988,7 @@
     }
     badgeText = '';
     if (abbreviationLettersArray.length === 0) {
-      chrome.storage.sync.get(null, function(allItemsInSyncedStorage) {
+      browser.storage.sync.get(null, function(allItemsInSyncedStorage) {
         if ((allItemsInSyncedStorage['kiwi_userPreferences'] != null) && allItemsInSyncedStorage['kiwi_userPreferences'].researchModeOnOff === 'off') {
           return badgeText = 'off';
         } else if (defaultUserPreferences.researchModeOnOff === 'off') {
@@ -2004,7 +2004,7 @@
   };
 
   updateBadgeText = function(text) {
-    return chrome.browserAction.setBadgeText({
+    return browser.browserAction.setBadgeText({
       'text': text.toString()
     });
   };
@@ -2071,10 +2071,10 @@
     }
     _autoOffAtUTCmilliTimestamp = setAutoOffTimer(resetTimerBool, _popupParcel.kiwi_userPreferences.autoOffAtUTCmilliTimestamp, _popupParcel.kiwi_userPreferences.autoOffTimerValue, _popupParcel.kiwi_userPreferences.autoOffTimerType, _popupParcel.kiwi_userPreferences.researchModeOnOff);
     _popupParcel.kiwi_userPreferences.autoOffAtUTCmilliTimestamp = _autoOffAtUTCmilliTimestamp;
-    return chrome.storage.sync.set({
+    return browser.storage.sync.set({
       'kiwi_userPreferences': _popupParcel.kiwi_userPreferences
     }, function() {
-      return chrome.storage.sync.set({
+      return browser.storage.sync.set({
         'kiwi_servicesInfo': _popupParcel.kiwi_servicesInfo
       }, function() {
         var formerActiveServicesList, newActiveServicesList, parcel;
@@ -2154,7 +2154,7 @@
   };
 
   turnResearchModeOff = function() {
-    return chrome.storage.sync.get(null, function(allItemsInSyncedStorage) {
+    return browser.storage.sync.get(null, function(allItemsInSyncedStorage) {
       var urlResults;
       if (kiwi_urlsResultsCache[tabUrl] != null) {
         urlResults = kiwi_urlsResultsCache[tabUrl];
@@ -2163,7 +2163,7 @@
       }
       if (allItemsInSyncedStorage.kiwi_userPreferences != null) {
         allItemsInSyncedStorage.kiwi_userPreferences.researchModeOnOff = 'off';
-        return chrome.storage.sync.set({
+        return browser.storage.sync.set({
           'kiwi_userPreferences': allItemsInSyncedStorage.kiwi_userPreferences
         }, function() {
           _set_popupParcel(urlResults, tabUrl, true);
@@ -2173,7 +2173,7 @@
         });
       } else {
         defaultUserPreferences.researchModeOnOff = 'off';
-        return chrome.storage.sync.set({
+        return browser.storage.sync.set({
           'kiwi_userPreferences': defaultUserPreferences
         }, function() {
           _set_popupParcel(urlResults, tabUrl, true);
@@ -2225,7 +2225,7 @@
             kiwi_servicesInfo: defaultServicesInfo,
             kiwi_userPreferences: defaultUserPreferences
           };
-          return chrome.storage.sync.set(setObj, function() {
+          return browser.storage.sync.set(setObj, function() {
             var isUrlBlocked;
             isUrlBlocked = is_url_blocked(defaultUserPreferences.urlSubstring_blacklists, tabUrl);
             if (isUrlBlocked === true && overrideResearchModeOff === false) {
@@ -2303,7 +2303,7 @@
       if (newServicesInfoAttribute) {
         setObj['kiwi_servicesInfo'] = newServicesInfo;
       }
-      return chrome.storage.sync.set(setObj, function() {
+      return browser.storage.sync.set(setObj, function() {
         if (newUserPrefsAttribute) {
           allItemsInSyncedStorage['kiwi_userPreferences'] = newUserPreferences;
         }
@@ -2334,7 +2334,7 @@
       popupOpen = false;
     }
     currentTime = Date.now();
-    return chrome.tabs.query({
+    return browser.tabs.query({
       currentWindow: true,
       active: true
     }, function(tabs) {
@@ -2363,7 +2363,7 @@
         }
         tabUrl_hashWordArray = CryptoJS.SHA512(tabUrl);
         tabUrl_hash = tabUrl_hashWordArray.toString(CryptoJS.enc.Latin1);
-        return chrome.storage.local.get(null, function(allItemsInLocalStorage) {
+        return browser.storage.local.get(null, function(allItemsInLocalStorage) {
           var historyString, sameURLCheck;
           sameURLCheck = true;
           historyString = reduceHashByHalf(tabUrl_hash);
@@ -2379,12 +2379,12 @@
           } else if (overrideSameURLCheck_popupOpen === true) {
             sameURLCheck = false;
           }
-          chrome.storage.local.set({
+          browser.storage.local.set({
             'persistentUrlHash': tabUrl_hash
           }, function() {});
           if (sameURLCheck === false) {
             updateBadgeText('');
-            return chrome.storage.sync.get(null, function(allItemsInSyncedStorage) {
+            return browser.storage.sync.get(null, function(allItemsInSyncedStorage) {
               return checkForNewDefaultUserPreferenceAttributes_thenProceedWithInitCheck(allItemsInSyncedStorage, allItemsInLocalStorage, overrideSameURLCheck_popupOpen, overrideResearchModeOff, sameURLCheck, tabUrl, currentTime, popupOpen);
             });
           }
@@ -2393,11 +2393,11 @@
     });
   };
 
-  chrome.tabs.onActivated.addListener(function() {
+  browser.tabs.onActivated.addListener(function() {
     return initIfNewURL();
   });
 
-  chrome.tabs.onUpdated.addListener(function(tabId, info) {
+  browser.tabs.onUpdated.addListener(function(tabId, info) {
     if ((tabTitleObject != null) && tabTitleObject.forUrl === tabUrl && (tabTitleObject.tabTitle == null)) {
       if (info.status === "complete") {
         initIfNewURL(true);
@@ -2408,7 +2408,7 @@
     }
   });
 
-  chrome.windows.onFocusChanged.addListener(function() {
+  browser.windows.onFocusChanged.addListener(function() {
     return initIfNewURL();
   });
 

--- a/package/manifest.json
+++ b/package/manifest.json
@@ -36,7 +36,7 @@
   "content_security_policy": "script-src 'self' https://www.google.com/uds/?file=search&v=1; object-src 'self'",
   
   "browser_action": {
-    "name": "Kiwi",
+    "default_title": "Kiwi",
     "default_icon": "kiwiFavico128.png",
     "default_popup": "popup.html"
   }

--- a/package/popup.html
+++ b/package/popup.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Kiwi</title>
+    <meta charset="utf-8">
     
     <link rel="stylesheet" href="popup.css"></link>
     

--- a/package/popup.js
+++ b/package/popup.js
@@ -1579,7 +1579,7 @@
     }
     switch (parcel.msg) {
       case 'kiwiPP_popupParcel_ready':
-        return chrome.tabs.query({
+        return browser.tabs.query({
           currentWindow: true,
           active: true
         }, function(tabs) {
@@ -1600,10 +1600,10 @@
 
   sendParcel = function(parcel) {
     var port;
-    port = chrome.extension.connect({
+    port = browser.runtime.connect({
       name: "kiwi_fromBackgroundToPopup"
     });
-    return chrome.tabs.query({
+    return browser.tabs.query({
       currentWindow: true,
       active: true
     }, function(tabs) {
@@ -1640,7 +1640,7 @@
     });
   };
 
-  chrome.extension.onConnect.addListener(function(port) {
+  browser.runtime.onConnect.addListener(function(port) {
     if (port.name === 'kiwi_fromBackgroundToPopup') {
       return port.onMessage.addListener(function(pkg) {
         return receiveParcel(pkg);


### PR DESCRIPTION
These changes provide basic support for Firefox, which would be necessary once Mozilla disables legacy extensions like kiwi-firefox for good (end of 2017).
I have not tested whether or not this breaks with chrome, but if it does, the chrome API objects (chrome, chrome.extension) and the firefox API objects (browser, browser.runtime) can be conditionally gated with something like this:

    var current_browser;
    var runtime;
    try {
        current_browser = browser;
        runtime = browser.runtime;
        browser.runtime.getBrowserInfo().then(function(info) {
            // pass (may check version number)
        });
    } catch(ex) {
        current_browser = chrome;
        runtime = chrome.extension;
    }

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/getBrowserInfo

Also, as a side-note, the tracking protection in Firefox blocks the reddit API call (I have not yet checked how to circumvent this).